### PR TITLE
no need to pause the playbook tests and assertions

### DIFF
--- a/test_proot.yml
+++ b/test_proot.yml
@@ -18,9 +18,6 @@
     tower_job_status_dir: /var/lib/awx/job_status
 
   tasks:
-    - name: 'Wait 30 seconds before proceeding...'
-      pause: seconds=30
-
     - command: find {{tower_tmp_dirs|join(' ')}} -mindepth 1 -maxdepth 1 -type d -regex '.*ansible_tower.*\|.*awx_proot.*'
       register: result
     - debug: var=result


### PR DESCRIPTION
* Maybe in the days of bubblewrap this was needed, but with proot, and
now runner isolation, we shouldn't need to delay our "jail" tests for
any reason.