### PR TITLE
add task summary playbook

### DIFF
--- a/test_summary.yml
+++ b/test_summary.yml
@@ -1,0 +1,30 @@
+---
+- name: Test Task Summaries
+  hosts: all
+  gather_facts: False
+  tasks:
+    - name: Rescue Test
+      block:
+        - name: Fail if the fail_main variable has been set on the host
+          fail:
+            msg: "YOU HAVE FAILED"
+          when: fail_main == True
+
+        - name: Fail if fail_and_ignore is set
+          fail:
+            msg: "It's okay"
+          when: fail_and_ignore == True
+          ignore_errors: True
+
+        - name: Debug task
+          debug:
+            msg: "This didn't fail."
+      rescue:
+        - name: Fail if fail_rescue is set
+          fail:
+            msg: "YOU HAVE FAILED AGAIN!"
+          when: fail_rescue == True
+
+        - name: Debug task
+          debug:
+            msg: "Rescue Successful"


### PR DESCRIPTION
This playbook will be used to test the new ansible playbook stats. When I create the test hosts using towerkit, I'll be setting boolean hostvars on them to trigger the behavior I want.

`fail_main`- fail the main part of the block and enter the rescue section
`fail_rescue` - fail the rescue block
`fail_and_ignore`- fail a task in the main block that is set to `ignore_errors`

`skipped` I get for free here, since any host that has `False` for the values will skip the task