### PR TITLE
Add sleep playbook to with_requirements branch

### DIFF
--- a/sleep.yml
+++ b/sleep.yml
@@ -1,0 +1,11 @@
+---
+
+- name: 'Test playbook to sleep for a specified interval'
+  hosts: all
+  gather_facts: false
+  vars:
+    sleep_interval: 30
+
+  tasks:
+    - name: sleep for a specified interval
+      command: sleep '{{ sleep_interval }}'


### PR DESCRIPTION
Moving forward, we do not expect to continue to download the roles folder to the project folder itself.

Because of that, we need to detect it relative to the job temporary files. That means we need a way to pause execution so that we can snoop around and look for them.

This adds the sleep playbook to this branch so that we can install galaxy requirements and sleep at the same time.