### PR TITLE
Update an assert on the tower_common tasks

### DIFF
--- a/tower_modules/tower_common/tasks/main.yml
+++ b/tower_modules/tower_common/tasks/main.yml
@@ -23,7 +23,7 @@
       - check_ssl_is_used is failed
       - >
           'Could not establish a secure connection' in check_ssl_is_used.msg
-          or 'OpenSSL.SSL.Error' in check_ssl_is_used.msg
+          or 'OpenSSL.SSL.Error' in check_ssl_is_used.module_stderr
         # 'Could not establish a secure connection': when pyOpenSSL isn't available
         # 'OpenSSL.SSL.Error': with pyOpenSSL, see https://github.com/urllib3/urllib3/pull/1517
 


### PR DESCRIPTION
When the OpenSSL.SSL.Error happens it goes to the module_stderr instead of being available on the msg.

Check this output for a reference:

```
fatal: [localhost]: FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\\n OMITTED THE REST OF THE TRACEBACK HERE ON PURPOSE \\n    raise exception_type(errors)\\nOpenSSL.SSL.Error: [('x509 certificate routines', 'X509_load_cert_crl_file', 'no certificate or crl found')]\\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE\\nSee stdout/stderr for the exact error",
    "rc": 1
}
...ignoring
```