### PR TITLE
Fix tower_job_list test

### DIFF
--- a/tower_modules/tower_job_list/tasks/main.yml
+++ b/tower_modules/tower_job_list/tasks/main.yml
@@ -36,4 +36,4 @@
 
 - assert:
     that:
-      - "{{ all_page_query.count }} == {{ all_page_query.results | length() }}"
+      - 'not all_page_query.next'


### PR DESCRIPTION
data.count and length(data.result) arent the same, this doesnt seem to
be the collection's fault, it seems to be the CLI's fault or the
API's fault