### PR TITLE
Remove "Wait" Tasks from JT and WFJT test playbooks

### DIFF
--- a/tower_modules/tower_job_template/tasks/main.yml
+++ b/tower_modules/tower_job_template/tasks/main.yml
@@ -14,20 +14,6 @@
     scm_credential: SCM Credential for JT
   register: result
 
-- name: Wait for the project to be status=successful
-  uri:
-    url: "{{ lookup('env', 'TOWER_HOST') }}/api/v2/projects/{{ result.id }}/"
-    method: GET
-    user: "{{ lookup('env', 'TOWER_USERNAME') }}"
-    password: "{{ lookup('env', 'TOWER_PASSWORD') }}"
-    validate_certs: false
-    force_basic_auth: true
-    return_content: true
-  register: result
-  until: result.json.summary_fields.last_update is defined and result.json.summary_fields.last_update.status == "successful"
-  retries: 60
-  delay: 1
-
 - name: Create a Job Template
   tower_job_template:
     name: "hello-world {{ lookup('randstr') }}"

--- a/tower_modules/tower_workflow_template/tasks/main.yml
+++ b/tower_modules/tower_workflow_template/tasks/main.yml
@@ -15,20 +15,6 @@
     scm_credential: SCM Credential for JT
   register: result
 
-- name: Wait for the project to be status=successful
-  uri:
-    url: "{{ lookup('env', 'TOWER_HOST') }}/api/v2/projects/{{ result.id }}/"
-    method: GET
-    user: "{{ lookup('env', 'TOWER_USERNAME') }}"
-    password: "{{ lookup('env', 'TOWER_PASSWORD') }}"
-    validate_certs: false
-    force_basic_auth: true
-    return_content: true
-  register: result
-  until: result.json.summary_fields.last_update is defined and result.json.summary_fields.last_update.status == "successful"
-  retries: 60
-  delay: 1
-
 - name: Create a Job Template
   tower_job_template:
     name: my-job-1


### PR DESCRIPTION
Re-implementing changes made here: https://github.com/ansible/test-playbooks/pull/95

https://github.com/ansible/awx/pull/5343 made the `wait` param true by default, so these test tasks are no longer necessary.