### PR TITLE
tower_project and tower_user Playbook Fixes

### DIFF
--- a/tower_modules/tower_project/tasks/main.yml
+++ b/tower_modules/tower_project/tasks/main.yml
@@ -45,6 +45,7 @@
   tower_credential:
     kind: scm
     name: TestCred
+    organization: TestOrg
 
   register: new_credentials
 

--- a/tower_modules/tower_project/tasks/main.yml
+++ b/tower_modules/tower_project/tasks/main.yml
@@ -16,7 +16,7 @@
     name: "git project"
     organization: Default
     scm_type: git
-    scm_url: https://github.com/ansible/ansible
+    scm_url: https://github.com/ansible/test-playbooks
     wait: False
   register: result
 
@@ -29,7 +29,7 @@
     name: "git project"
     organization: Default
     scm_type: git
-    scm_url: https://github.com/ansible/ansible
+    scm_url: https://github.com/ansible/test-playbooks
     wait: True
   register: result
 
@@ -63,8 +63,8 @@
     name: "TestProject {{ project_name_rand }}"
     organization: TestOrg1
     scm_type: git
-    scm_url: "https://github.com/ansible/ansible"
-    scm_credential: TestCred1
+    scm_url: https://github.com/ansible/test-playbooks
+    scm_credential: "{{ new_credentials.results[0].id }}"
   register: result
 
 - assert:
@@ -76,14 +76,14 @@
     name: "TestProject {{ project_name_rand }}"
     organization: Non Existing Org
     scm_type: git
-    scm_url: "https://github.com/ansible/ansible"
-    scm_credential: TestCred1
+    scm_url: https://github.com/ansible/test-playbooks
+    scm_credential: "{{ new_credentials.results[0].id }}"
   register: result
   ignore_errors: true
 
 - assert:
     that:
-      - "result.msg == 'The organizations Non-Existing Org was not found on the Tower server' or
+      - "result.msg == 'The organizations Non Existing Org was not found on the Tower server' or
         result.msg == 'Failed to update project, organization not found: Non Existing Org'"
 
 - name: Check module fails with correct msg when given non-existing credential as param
@@ -91,7 +91,7 @@
     name: "TestProject {{ project_name_rand }}"
     organization: TestOrg1
     scm_type: git
-    scm_url: "https://github.com/ansible/ansible"
+    scm_url: https://github.com/ansible/test-playbooks
     scm_credential: Non Existing Credential
   register: result
   ignore_errors: true

--- a/tower_modules/tower_project/tasks/main.yml
+++ b/tower_modules/tower_project/tasks/main.yml
@@ -64,7 +64,7 @@
     organization: TestOrg1
     scm_type: git
     scm_url: https://github.com/ansible/test-playbooks
-    scm_credential: "{{ new_credentials.results[0].id }}"
+    scm_credential: "{{ new_credentials.results[0].id | default('TestCred1') }}"
   register: result
 
 - assert:
@@ -77,7 +77,7 @@
     organization: Non Existing Org
     scm_type: git
     scm_url: https://github.com/ansible/test-playbooks
-    scm_credential: "{{ new_credentials.results[0].id }}"
+    scm_credential: "{{ new_credentials.results[0].id | default('TestCred1') }}"
   register: result
   ignore_errors: true
 

--- a/tower_modules/tower_project/tasks/main.yml
+++ b/tower_modules/tower_project/tasks/main.yml
@@ -39,19 +39,13 @@
 
 - name: Create organizations
   tower_organization:
-    name: "{{ item }}"
-  loop:
-    - TestOrg1
-    - TestOrg2
+    name: TestOrg
 
 - name: Create credential
   tower_credential:
     kind: scm
-    name: TestCred1
-    organization: "{{ item }}"
-  loop:
-    - TestOrg2
-    - TestOrg1
+    name: TestCred
+
   register: new_credentials
 
 - name: Generate random project name appender
@@ -61,10 +55,10 @@
 - name: Create a new test project
   tower_project:
     name: "TestProject {{ project_name_rand }}"
-    organization: TestOrg1
+    organization: TestOrg
     scm_type: git
     scm_url: https://github.com/ansible/test-playbooks
-    scm_credential: "{{ new_credentials.results[0].id | default('TestCred1') }}"
+    scm_credential: TestCred
   register: result
 
 - assert:
@@ -77,7 +71,7 @@
     organization: Non Existing Org
     scm_type: git
     scm_url: https://github.com/ansible/test-playbooks
-    scm_credential: "{{ new_credentials.results[0].id | default('TestCred1') }}"
+    scm_credential: TestCred
   register: result
   ignore_errors: true
 
@@ -89,7 +83,7 @@
 - name: Check module fails with correct msg when given non-existing credential as param
   tower_project:
     name: "TestProject {{ project_name_rand }}"
-    organization: TestOrg1
+    organization: TestOrg
     scm_type: git
     scm_url: https://github.com/ansible/test-playbooks
     scm_credential: Non Existing Credential
@@ -104,5 +98,5 @@
 - name: Delete the test project
   tower_project:
     name: "TestProject {{ project_name_rand }}"
-    organization: TestOrg1
+    organization: TestOrg
     state: absent

--- a/tower_modules/tower_user/tasks/main.yml
+++ b/tower_modules/tower_user/tasks/main.yml
@@ -90,5 +90,5 @@
 
 - assert:
     that:
-      - "result.msg =='Unable to resolve tower_host ([Errno 8] nodename nor servname provided, or not known): foo.invalid' or
+      - "'Unable to resolve tower_host' in result.msg or
         'Can not verify ssl with non-https protocol' in result.exception"


### PR DESCRIPTION
- Create just one Test Org and Test Cred to simplify things
- Point the `scm_url` to a smaller repo in order to reduce the amount of time it takes tasks with that parameter to run
- Update assert statement in `tower_user` playbooks