### PR TITLE
Add playbook to optionally stress system resources

### DIFF
--- a/stress.yml
+++ b/stress.yml
@@ -1,0 +1,9 @@
+---
+
+- hosts: all
+  gather_facts: false
+  vars:
+    stress_args: "--vm 16 --vm-bytes 1024M --timeout 60"
+  tasks:
+    - name: "Run stress command"
+      command: "stress {{ stress_args }}"


### PR DESCRIPTION
I'd like to test w/ memory intensive playbook at this seems like the cleaneset way to do that.

Optionally, this could also be used to stress CPU consumption of playbook or disk consumption.