### PR TITLE
[DO NOT MERGE] Add example that requires python dependency

### DIFF
--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -1,0 +1,3 @@
+collections:
+  - name: https://github.com/AlanCoding/awx.git#awx_collection,ee_req
+    type: git  

--- a/rrule.yml
+++ b/rrule.yml
@@ -1,0 +1,14 @@
+---
+- hosts: localhost
+  gather_facts: false
+  connection: local
+  tasks:
+  - name: Debug using the rrule plugin
+    debug:
+      msg: >
+        {{ query(
+          'awx.awx.tower_schedule_rrule',
+          'minute',
+          start_date='2020-4-16 03:45:07',
+          end_on='2'
+        ) }}


### PR DESCRIPTION
requires `ansible-builder` to build the EE and then plug that in

...or actually, it should eventually work with some of the pre-baked EEs, but that's a bit further down the line.