### PR TITLE
[DO NOT MERGE] Add content to use local_roles, PR 140 content

### DIFF
--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -1,0 +1,7 @@
+## desired, but not possible because lack of support for custom refspecs
+# - src: git+https://github.com/ansible/test-playbooks.git
+#   version: pull/140/head
+
+- src: git+https://github.com/AlanCoding/test-playbooks.git
+  version: local_roles
+  name: remote_test_role

--- a/use_debug_role.yml
+++ b/use_debug_role.yml
@@ -1,0 +1,6 @@
+---
+- hosts: all
+  connection: local
+  gather_facts: false
+  roles:
+    - role: remote_test_role


### PR DESCRIPTION
Makes use of https://github.com/ansible/test-playbooks/pull/140 in the role requirements

We can't use the refspec here, so I don't see any other easy choice aside from using my fork, unless we want to add it as a branch.