### PR TITLE
chatty_payload.yml: generate events payload with specific size

### DIFF
--- a/chatty_payload.yml
+++ b/chatty_payload.yml
@@ -1,0 +1,11 @@
+---
+- hosts: all
+  gather_facts: no
+  vars:
+    message_size: 1024 #message size in Bytes[1KB]
+    num_messages: 10  #number of messages
+    chatty_message: "{{ '$' * message_size }}"
+  tasks:
+    - debug:
+          msg: "{{ chatty_message }}"
+      with_sequence: "count={{ num_messages }}"


### PR DESCRIPTION
#### Highlights of the PR
`chatty_payload.yml` is created to understand how `job events lag` changes w.r.t the payload size.  We have been using `chatty_task.yml` as a source to generate large number of events for testing and we had fixed message size. Through this PR we can generate events payload with variable message size (message sizes are defined in Bytes) 