### PR TITLE
Add playbook that produces only rescued status

### DIFF
--- a/rescued_not_failed.yml
+++ b/rescued_not_failed.yml
@@ -1,0 +1,13 @@
+- hosts: localhost
+  gather_facts: false
+  connection: local
+  tasks:
+  - name: Fail and rescue - collection of tasks
+    block:
+      - fail:
+          msg: "HALP!!! time number {{ item }}"
+        loop:
+          - 1
+          - 2
+    rescue:
+      - debug: msg="ε-(´・｀) ﾌ"


### PR DESCRIPTION
Written for https://github.com/ansible/awx/issues/7869

```
$ ansible-playbook rescued_not_failed.yml 
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under
development. This is a rapidly changing source of code and can become unstable at any point.
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [localhost] *************************************************************************************************************************************************************

TASK [fail] ******************************************************************************************************************************************************************
failed: [localhost] (item=1) => {"ansible_loop_var": "item", "changed": false, "item": 1, "msg": "HALP!!! time number 1"}
failed: [localhost] (item=2) => {"ansible_loop_var": "item", "changed": false, "item": 2, "msg": "HALP!!! time number 2"}

TASK [debug] *****************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "ε-(´・｀) ﾌ"
}

PLAY RECAP *******************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=1    ignored=0   
```

