### PR TITLE
Work around Ansible bug by pre-creating async directory

### DIFF
--- a/async_tasks.yml
+++ b/async_tasks.yml
@@ -3,6 +3,13 @@
 - hosts: all
   gather_facts: false
   tasks:
+
+  - name: Create the async directory to prevent race conditions
+    file:
+      path: ~/.ansible_async
+      state: directory
+    run_once: true
+
   - name: Poll a sleep
     shell: "sleep 10"
     async: 30


### PR DESCRIPTION
I saw this error in some integration tests, and I decided, this is the last one.

```
TASK [Poll a sleep] ************************************************************
fatal: [HostDealCombination265463884742900759354858707050726789491410052279873810063]: FAILED! => {"ansible_facts": {"discovered_interpreter_python": "/usr/bin/python"}, "changed": true, "module_stderr": "", "module_stdout": "{\\"failed\\": 1, \\"msg\\": \\"could not create: /home/runner/.ansible_async\\"}\\n{\\"failed\\": 1, \\"msg\\": \\"could not create: /home/runner/.ansible_async\\"}\\n{\\"failed\\": 1, \\"msg\\": \\"could not create: /home/runner/.ansible_async\\"}\\n{\\"started\\": 1, \\"finished\\": 0, \\"ansible_job_id\\": \\"771508686001.111\\", \\"results_file\\": \\"/home/runner/.ansible_async/771508686001.111\\", \\"_ansible_suppress_tmpdir_delete\\": true}\\n", "msg": "MODULE FAILURE\\nSee stdout/stderr for the exact error", "rc": 0}
ASYNC POLL on HostSurpriseClock4429228878506642654221863973011503065272293717195929757: jid=203771178819.114 started=1 finished=0
ASYNC POLL on HostCoverBlack358205000332319733941234394668256930088001041431856775554: jid=335443517235.115 started=1 finished=0
ASYNC POLL on HostWearSavings113703871323749907058741743306435820182331283600387143539: jid=446938465099.112 started=1 finished=0
ASYNC POLL on HostEnergyGather2528950010177431975668315886631710619522668627374989744: jid=111996908583.113 started=1 finished=0
changed: [HostSurpriseClock4429228878506642654221863973011503065272293717195929757]
changed: [HostCoverBlack358205000332319733941234394668256930088001041431856775554]
changed: [HostEnergyGather2528950010177431975668315886631710619522668627374989744]
changed: [HostWearSavings113703871323749907058741743306435820182331283600387143539]
```

I [filed a bug](https://github.com/ansible/ansible/issues/59306) in Ansible core, describing how it's a bug in their logic for pretty any locally run async stuff on a fresh machine (see: integration testing). I made [a pull request](https://github.com/ansible/ansible/pull/59394) that fixes it, and made adjustments from feedback, and it was even approved.

However, it has been left un-merged, and all the while this error has continued to plague me.

Because of how this is a race condition, it's difficult to verify the fix, but I did run the playbook and it runs fine. Based on my understanding of the mechanism, I expect that this should work.