### PR TITLE
Add 60 second sleep inventory script

### DIFF
--- a/inventories/dyn_inventory_sleep_60s.py
+++ b/inventories/dyn_inventory_sleep_60s.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+from datetime import datetime
+import json
+
+import time
+
+inventory = {
+    'all': {'vars': {'ansible_connection': 'local'}},
+    'ungrouped': {'hosts': ['localhost']},
+    '_meta': {'hostvars': {'localhost': {
+        'current_time': str(datetime.now())
+    }}}
+}
+
+
+if __name__ == '__main__':
+    time.sleep(60)
+    print(json.dumps(inventory, indent=4))


### PR DESCRIPTION
I have increasingly been having issues formulating inventory update timeout tests. I added a 5 second sleep script before, but 60 seconds is more appropriate for the real needs looking at canceling and timing out.