### PR TITLE
Make playbook work inside EE

### DIFF
--- a/test_ansible_shell.yml
+++ b/test_ansible_shell.yml
@@ -5,12 +5,11 @@
   tasks:
     - name: Write inventory file
       blockinfile:
-        path: '{{ playbook_dir }}/inventory.ansible.shell'
+        path: '/tmp/inventory.ansible.shell'
         block: |
           localhost ansible_connection=local
         state: present
         create: True
 
     - name: Run Playbook
-      shell: "ANSIBLE_NOCOLOR=1 ansible-playbook -i './inventory.ansible.shell' ./ping.yml"
-
+      shell: "ANSIBLE_NOCOLOR=1 ansible-playbook -i '/tmp/inventory.ansible.shell' ./ping.yml"


### PR DESCRIPTION
Without this I was seeing:

```
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_blockinfile_payload_t104dg01/ansible_blockinfile_payload.zip/ansible/module_utils/basic.py", line 2372, in atomic_move
    os.rename(b_src, b_dest)
OSError: [Errno 18] Invalid cross-device link: b'/root/.ansible/tmp/ansible-tmp-1607124578.7949378-49-239870856360909/tmpwtw0xyhd' -> b'/runner/project/inventory.ansible.shell'
```