### PR TITLE
Change all shebangs to python3

### DIFF
--- a/inventories/changes.py
+++ b/inventories/changes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import json
 

--- a/inventories/changes_slow.py
+++ b/inventories/changes_slow.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import json
 import time

--- a/inventories/dyn_inventory.py
+++ b/inventories/dyn_inventory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from argparse import ArgumentParser
 import json
 

--- a/inventories/dyn_inventory_sleep_60s.py
+++ b/inventories/dyn_inventory_sleep_60s.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from datetime import datetime
 import json

--- a/inventories/dyn_inventory_test_env.py
+++ b/inventories/dyn_inventory_test_env.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from argparse import ArgumentParser
 from datetime import datetime
 import json

--- a/inventories/dyn_inventory_test_two_env.py
+++ b/inventories/dyn_inventory_test_two_env.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from argparse import ArgumentParser
 from datetime import datetime
 import json

--- a/inventories/invalid_dyn_inventory.py
+++ b/inventories/invalid_dyn_inventory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from argparse import ArgumentParser
 import json
 

--- a/inventories/metaless_dyn_inventory.py
+++ b/inventories/metaless_dyn_inventory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from argparse import ArgumentParser
 import json
 

--- a/inventories/more_inventories/dyn_inventory.py
+++ b/inventories/more_inventories/dyn_inventory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from argparse import ArgumentParser
 import json
 

--- a/inventories/more_inventories/even_more_inventories/dyn_inventory.py
+++ b/inventories/more_inventories/even_more_inventories/dyn_inventory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from argparse import ArgumentParser
 import json
 

--- a/library/test_scan_facts.py
+++ b/library/test_scan_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import os


### PR DESCRIPTION
Fallout from https://github.com/ansible/ansible-runner/pull/581 I believe. There is no `python` in the base image, just `python3`