### PR TITLE
Pick up some nuanced differences from old awxkit script

### DIFF
--- a/inventories/script_migrations/script_source.py
+++ b/inventories/script_migrations/script_source.py
@@ -6,16 +6,19 @@ import random
 import string
 
 
-UNICODE_LETTERS = string.ascii_letters + ("읤僪䠱빨胀콩厺殜赬镗צּ䂕ᆑ䭆蜅펵ꂢ綌靸縹聂傈㟩륯Ȳ北벊렙ぶ逖ϥ谺艣뒉摳")
+random.seed(29973595994172)
 
 
-def random_str():
-    return "".join([random.choice(UNICODE_LETTERS) for _ in range(10)])
+def random_str(non_ascii=True):
+    char_list = string.ascii_letters
+    if non_ascii:
+        char_list += ("읤僪䠱빨胀콩厺殜赬镗צּ䂕ᆑ䭆蜅펵ꂢ綌靸縹聂傈㟩륯Ȳ北벊렙ぶ逖ϥ谺艣뒉摳")
+    return "".join([random.choice(char_list) for _ in range(10)])
 
 
 inventory = dict()
 
-group_name = "group_%s" % random_str()
+group_name = "group_%s" % random_str(non_ascii=False)
 
 inventory[group_name] = dict()
 inventory[group_name]["hosts"] = list()


### PR DESCRIPTION
I need to make this behave more like the old script at:

https://github.com/ansible/awx/blob/9a61c4368784c421e47551e4175020ced116f56e/awxkit/awxkit/api/pages/inventory.py#L150-L171

 - group name did not have unicode in it
 - we can't use a different random seed each time (we could consider a later enhancement for each inventory to provide its own seed)