### PR TITLE
Remove and Replace source_script Parameter

### DIFF
--- a/test_collections/test_tower_inventory_source.j2
+++ b/test_collections/test_tower_inventory_source.j2
@@ -4,6 +4,7 @@
     inventory: {{ inventory }} 
     description: {{ description }}
     source: {{ source }}
-    source_script: {{ source_script }} 
+    source_project: {{ source_project }}
+    source_path: {{ source_path }}
     execution_environment: {{ execution_environment }}
   register: inventory_source


### PR DESCRIPTION
PR https://github.com/ansible/awx/pull/9822 removed the `source_script` parameter from the `inventory_source` AWX Collection module. This PR updates the `test_collections/test_tower_inventory_source.j2` file to call the correct parameters instead.
