### PR TITLE
Remove 'source' as a Parameter

### DIFF
--- a/test_collections/test_tower_inventory_source.j2
+++ b/test_collections/test_tower_inventory_source.j2
@@ -3,7 +3,6 @@
     name: {{ name }}
     inventory: {{ inventory }} 
     description: {{ description }}
-    source: {{ source }}
     source_project: {{ source_project }}
     source_path: {{ source_path }}
     execution_environment: {{ execution_environment }}


### PR DESCRIPTION
Another change related to PR https://github.com/ansible/awx/pull/9822; removing `source` as a parameter here since it is no longer necessary (the test now points to an `scm` source, which is the default option for that parameter).