### PR TITLE
list collections before running jinja'd template

### DIFF
--- a/tower_collection_smoke.yml
+++ b/tower_collection_smoke.yml
@@ -4,6 +4,16 @@
   vars:
     collection_id: awx.awx
   tasks:
+    - name: "List what collections are installed (only available with ansible 2.10+)"
+      shell: "ansible-galaxy collection list"
+      register: ansible_collections_list
+      when: ansible_version.full is version('2.10.0', '>=')
+
+    - name: "Echo what collections are installed (only available with ansible 2.10+)"
+      debug:
+        msg: "{{ ansible_collections_list.stdout_lines }}"
+      when: ansible_version.full is version('2.10.0', '>=')
+
     - name: "Create playbook to call with collection FQCN"
       template:
         src: tower_collection_smoke.j2


### PR DESCRIPTION
this helps us understand failures if we have a mismatch of what
collection is installed vs. what is templated