### PR TITLE
Change all shebangs to python3

### DIFF
--- a/inventories/changes.py
+++ b/inventories/changes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import json
 

--- a/inventories/changes_slow.py
+++ b/inventories/changes_slow.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import json
 import time

--- a/inventories/dyn_inventory.py
+++ b/inventories/dyn_inventory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from argparse import ArgumentParser
 import json
 

--- a/inventories/dyn_inventory_sleep_60s.py
+++ b/inventories/dyn_inventory_sleep_60s.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from datetime import datetime
 import json

--- a/inventories/dyn_inventory_test_env.py
+++ b/inventories/dyn_inventory_test_env.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from argparse import ArgumentParser
 from datetime import datetime
 import json

--- a/inventories/dyn_inventory_test_two_env.py
+++ b/inventories/dyn_inventory_test_two_env.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from argparse import ArgumentParser
 from datetime import datetime
 import json

--- a/inventories/invalid_dyn_inventory.py
+++ b/inventories/invalid_dyn_inventory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from argparse import ArgumentParser
 import json
 

--- a/inventories/metaless_dyn_inventory.py
+++ b/inventories/metaless_dyn_inventory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from argparse import ArgumentParser
 import json
 

--- a/inventories/more_inventories/dyn_inventory.py
+++ b/inventories/more_inventories/dyn_inventory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from argparse import ArgumentParser
 import json
 

--- a/inventories/more_inventories/even_more_inventories/dyn_inventory.py
+++ b/inventories/more_inventories/even_more_inventories/dyn_inventory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from argparse import ArgumentParser
 import json
 

--- a/inventories/script_migrations/ansible_host.py
+++ b/inventories/script_migrations/ansible_host.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import json
 import os

--- a/inventories/script_migrations/bad_script_1.py
+++ b/inventories/script_migrations/bad_script_1.py
@@ -1,2 +1,2 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 raise Exception("Fail!")

--- a/inventories/script_migrations/bad_script_2.py
+++ b/inventories/script_migrations/bad_script_2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 
 sys.exit(1)

--- a/inventories/script_migrations/bad_script_3.py
+++ b/inventories/script_migrations/bad_script_3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import json
 
 print(json.dumps({}))

--- a/inventories/script_migrations/basic_structure.py
+++ b/inventories/script_migrations/basic_structure.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import json
 

--- a/inventories/script_migrations/credential_file.py
+++ b/inventories/script_migrations/credential_file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import os, sys

--- a/inventories/script_migrations/custom_script.py
+++ b/inventories/script_migrations/custom_script.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import json
 import uuid

--- a/inventories/script_migrations/delete_group_1_custom_script.py
+++ b/inventories/script_migrations/delete_group_1_custom_script.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import json
 import uuid

--- a/inventories/script_migrations/delete_group_2_custom_script.py
+++ b/inventories/script_migrations/delete_group_2_custom_script.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import json
 import uuid

--- a/inventories/script_migrations/delete_group_3_custom_script.py
+++ b/inventories/script_migrations/delete_group_3_custom_script.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import json
 import uuid

--- a/inventories/script_migrations/empty_group.py
+++ b/inventories/script_migrations/empty_group.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import json
 

--- a/inventories/script_migrations/encrypted_var.py
+++ b/inventories/script_migrations/encrypted_var.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import json
 

--- a/inventories/script_migrations/large_5.py
+++ b/inventories/script_migrations/large_5.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import json
 
 

--- a/inventories/script_migrations/large_5000.py
+++ b/inventories/script_migrations/large_5000.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import json
 
 

--- a/inventories/script_migrations/large_dense.py
+++ b/inventories/script_migrations/large_dense.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import json
 import os
 

--- a/inventories/script_migrations/large_hostvars.py
+++ b/inventories/script_migrations/large_hostvars.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import json
 import random
 import string

--- a/inventories/script_migrations/large_sparse.py
+++ b/inventories/script_migrations/large_sparse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import json
 import os
 

--- a/inventories/script_migrations/ordering.py
+++ b/inventories/script_migrations/ordering.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import json
 

--- a/inventories/script_migrations/overwrite1.py
+++ b/inventories/script_migrations/overwrite1.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import json
 

--- a/inventories/script_migrations/overwrite2.py
+++ b/inventories/script_migrations/overwrite2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # changes made relative to overwrite1.py:

--- a/inventories/script_migrations/script_source.py
+++ b/inventories/script_migrations/script_source.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import json

--- a/inventories/script_migrations/sleep_20s.py
+++ b/inventories/script_migrations/sleep_20s.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import json, time
 
 time.sleep(20)

--- a/inventories/script_migrations/sleep_2s.py
+++ b/inventories/script_migrations/sleep_2s.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import json, time
 
 time.sleep(2)

--- a/inventories/script_migrations/sleep_300s.py
+++ b/inventories/script_migrations/sleep_300s.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import json, time
 
 time.sleep(300)

--- a/inventories/script_migrations/stderr.py
+++ b/inventories/script_migrations/stderr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 import sys
 

--- a/inventories/script_migrations/test_isolation.py
+++ b/inventories/script_migrations/test_isolation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import json
 import re

--- a/inventories/script_migrations/test_limit.py
+++ b/inventories/script_migrations/test_limit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import json
 
 # Create hosts and groups

--- a/library/test_scan_facts.py
+++ b/library/test_scan_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import os


### PR DESCRIPTION
Back when https://github.com/ansible/test-playbooks/pull/162 was up, it was still up in the air which we _could_ use

so we merged https://github.com/ansible/test-playbooks/pull/176 instead

Now, time has passed. Enough time has probably passed that python2 environments are no longer supported, so maybe we can do this.