### PR TITLE
Add playbook to debug variables without templating extra_vars

### DIFF
--- a/debug_dynamic_variable.yml
+++ b/debug_dynamic_variable.yml
@@ -1,0 +1,11 @@
+---
+- hosts: all
+  connection: local
+  gather_facts: false
+  vars:
+    default_var: foobar
+    var_name: default_var
+    leading_text: "specified_var_is:"
+  tasks:
+    - name: Print value of variable specified by var_name contents
+      debug: msg="{{ leading_text }}{{ lookup('vars', var_name) }}"


### PR DESCRIPTION
```
(env) [alancoding@alan-red-hat test-playbooks]$ ansible-playbook -i localhost, debug_dynamic_variable.yml -e leading_text="var1: " -e var_name=alan -e alan=steve
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or
trying out features under development. This is a rapidly changing source of code and can become unstable at any point.

PLAY [all] ***********************************************************************************************************************************************

TASK [Print value of variable specified by var_name contents] ********************************************************************************************
ok: [localhost] => {
    "msg": "var1:steve"
}

PLAY RECAP ***********************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

```