### PR TITLE
add playbook that sleeps between messages

### DIFF
--- a/debug-loop.yml
+++ b/debug-loop.yml
@@ -1,0 +1,12 @@
+---
+- hosts: all
+  gather_facts: false
+  vars:
+    sleep_interval: 1
+    num_messages: 50
+  tasks:
+    - name: debug and sleep for configured time
+      include_tasks: debug_and_sleep.yml
+      vars:
+        message_number: "{{ item }}"
+      loop: "{{ range(0, num_messages|int)|list }}"

--- a/debug_and_sleep.yml
+++ b/debug_and_sleep.yml
@@ -1,0 +1,3 @@
+---
+- debug: msg="{{ message_number|default(1) }}"
+- pause: seconds="{{ sleep_interval|default(1)|int }}"


### PR DESCRIPTION
This is like debug-50, except it can print any number of messages and sleep any amount of time between. This is good for when you want a workload with burts of output, but that has lulls of activity.