### PR TITLE
Add a playbook that sleeps long enough to be canceled 

### DIFF
--- a/long_running.yml
+++ b/long_running.yml
@@ -1,0 +1,9 @@
+---
+
+- name: 'Test playbook that sleeps for long so there's time to cancel it'
+  hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: sleep for long
+      command: sleep 100000


### PR DESCRIPTION
For testing that a Job can be canceled from various places in UI we need a playbook that runs long enough for Cypress to navigate around UI. We also want something that does nothing (and shouldn't be able to fail prematurely). 