### PR TITLE
fix: adapt playbooks to ansible-core 2.20

### DIFF
--- a/gen_host_status_loop.yml
+++ b/gen_host_status_loop.yml
@@ -1,7 +1,7 @@
 - hosts: all
   gather_facts: false
   tasks:
-  - include: gen_host_status_base.yml
+  - include_tasks: gen_host_status_base.yml
     loop:
       - 1
       - 2

--- a/test_tags.yml
+++ b/test_tags.yml
@@ -33,5 +33,5 @@
   roles:
     - { role: test_tag_role, test_tag_role_msg: 'role_with_tag', tags: [ 'tag_role' ] }
 
-- include: test_tags_include.yml
+- import_playbook: test_tags_include.yml
   tags: tag_include

--- a/tower_collection_smoke.j2
+++ b/tower_collection_smoke.j2
@@ -1,6 +1,7 @@
 - name: Launch a Job Template
   {{ collection_id }}.tower_job_launch:
     job_template: "Demo Job Template"
+    request_timeout: 10
   register: job
 
 - assert:
@@ -12,26 +13,29 @@
   {{ collection_id }}.tower_job_list:
     query:
       id: "{{ '{{' }} job.id {{ '}}' }}"
+    request_timeout: 10
   register: matching_jobs
 
 - assert:
     that:
-      - "{{ '{{' }} matching_jobs.count {{ '}}' }} == 1"
+      - "matching_jobs.count == 1"
 
 - name: List failed jobs (which don't exist)
   {{ collection_id }}.tower_job_list:
     status: failed
-    query: 
+    query:
       id: "{{ '{{' }} job.id {{ '}}' }}"
+    request_timeout: 10
   register: successful_jobs
 
 - assert:
     that:
-      - "{{ '{{' }} successful_jobs.count {{ '}}' }} == 0"
+      - "successful_jobs.count == 0"
 
 - name: Get ALL result pages!
   {{ collection_id }}.tower_job_list:
     all_pages: True
+    request_timeout: 10
   register: all_page_query
 
 - assert:

--- a/tower_collection_smoke.yml
+++ b/tower_collection_smoke.yml
@@ -21,7 +21,7 @@
         src: "{{ src_file }}"
         dest: "{{ dest_file }}"
 
-    - include: "{{ dest_file }}"
+    - include_tasks: "{{ dest_file }}"
 
     - name: "Delete dynamic playbook"
       file:


### PR DESCRIPTION
Modify playbooks to support ansible-core 2.20, as the `include` clause has been removed.