### PR TITLE
Add galaxy.yml to testing.indirect_host_counting collection

### DIFF
--- a/collections/ansible_collections/testing/indirect_host_counting/galaxy.yml
+++ b/collections/ansible_collections/testing/indirect_host_counting/galaxy.yml
@@ -1,0 +1,7 @@
+---
+namespace: testing
+name: indirect_host_counting
+version: 0.0.1
+description: Test collection for indirect node counting
+authors: ['AWX Project Contributors']
+dependencies: {}


### PR DESCRIPTION
## Summary

- Adds a `galaxy.yml` metadata file to the `testing.indirect_host_counting` test collection, which was missing both `galaxy.yml` and `MANIFEST.json`
- This suppresses a misleading Ansible warning that appears in job output when indirect node counting is enabled

## Context

When the `FEATURE_INDIRECT_NODE_COUNTING_ENABLED` flag is active, the `indirect_instance_count` callback plugin scans all collections on `ANSIBLE_COLLECTIONS_PATH`. The `testing.indirect_host_counting` collection (used by `check_produce_inc_output.yml`) lacked any metadata files, causing Ansible to emit:

```
[WARNING]: Collection at '/runner/project/collections/ansible_collections/testing/indirect_host_counting'
does not have a MANIFEST.json file, nor has it galaxy.yml: cannot detect version.
```

This warning is visible to customers in job output and is likely to generate support tickets.

## Test plan

- [ ] Run `test_indirect_node_counting` from `aap-test-suite` and verify the warning no longer appears in job output
- [ ] Verify indirect node counting still functions correctly

Closes: AAP-70324

🤖 Generated with [Claude Code](https://claude.com/claude-code)