### PR TITLE
Add missing readme field to indirect_host_counting galaxy.yml

### DIFF
--- a/collections/ansible_collections/testing/indirect_host_counting/galaxy.yml
+++ b/collections/ansible_collections/testing/indirect_host_counting/galaxy.yml
@@ -4,4 +4,5 @@ name: indirect_host_counting
 version: 0.0.1
 description: Test collection for indirect node counting
 authors: ['AWX Project Contributors']
+readme: README.md
 dependencies: {}


### PR DESCRIPTION
## Summary

- Adds the mandatory `readme` field to `testing.indirect_host_counting` collection's `galaxy.yml`
- Without it, `ansible-galaxy` warns: *"The collection galaxy.yml is missing the following mandatory keys: readme"*

Follow-up to #321.

## Verification

Before (with galaxy.yml but no `readme` key):
```
[WARNING]: The collection galaxy.yml at '...' is missing the following mandatory keys: readme
```

After:
```
# No warnings
Collection                               Version
testing.indirect_host_counting           0.0.1
```

Closes: AAP-70324

🤖 Generated with [Claude Code](https://claude.com/claude-code)